### PR TITLE
ADD ArduinoBuild.yml as GitHub Actions

### DIFF
--- a/.github/workflows/ArduinoBuild.yml
+++ b/.github/workflows/ArduinoBuild.yml
@@ -1,0 +1,55 @@
+name: Arduino Build
+
+env:
+  CLI_ARGS: --build-property compiler.c.extra_flags="-Wno-error=unused-const-variable" --build-property compiler.cpp.extra_flags="-Wno-error=array-bounds"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: ${{matrix.board}}@${{matrix.platform-version}}
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+
+        platform-url:
+          - https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json
+
+        board:
+          # M5Stack for 3D matrix
+          - m5stack-fire
+          - m5stack-core2
+          - m5stick-c
+
+        platform-version:
+          - 2.0.6
+
+        include:
+          - { board: m5stack-fire, platform: esp32, archi: esp32, required-libraries: M5Stack, sketch-path: m5stack_fire/*/, ... }
+          - { board: m5stack-core2, platform: esp32, archi: esp32, required-libraries: M5Core2, sketch-path: m5stack_core2/*/, ... }
+          - { board: m5stick-c,    platform: esp32, archi: esp32, required-libraries: M5StickC, sketch-path: m5stickc/*/, ... }
+
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Compile example
+        uses: ArminJo/arduino-test-compile@master
+        with:
+          arduino-board-fqbn: ${{matrix.platform}}:${{matrix.archi}}:${{matrix.board}}
+          arduino-platform: ${{matrix.platform}}:${{matrix.archi}}@${{matrix.platform-version}}
+          platform-url: ${{ matrix.platform-url }}
+          required-libraries: ${{ matrix.required-libraries }}
+          extra-arduino-cli-args: ${{ env.CLI_ARGS }}
+          sketch-names: "*.ino"
+          sketch-names-find-start: ${{ matrix.sketch-path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+-   ADD ArduinoBuild.yml as GitHub Actions (#2)
 -   ADD ino files for M5StickC Plus (#1)
 -   first commit


### PR DESCRIPTION
This PR adds ArduinoBuild.yml as GitHub Actions.